### PR TITLE
Out of bounds exception

### DIFF
--- a/PinYin4Objc/Classes/PinyinFormatter.m
+++ b/PinYin4Objc/Classes/PinyinFormatter.m
@@ -119,9 +119,9 @@ static unichar numericValues[] = {
         int vowelLocation = rowIndex * 5 + columnIndex;
         unichar markedVowel = [allMarkedVowelStr characterAtIndex:vowelLocation];
         NSMutableString *resultBuffer = [[NSMutableString alloc] init];
-          [resultBuffer appendString:[[lowerCasePinyinStr substringToIndex:indexOfUnmarkedVowel+1] stringByReplacingOccurrencesOfString:@"v" withString:@"ü"]];
-        [resultBuffer appendFormat:@"%C",markedVowel];
-          [resultBuffer appendString:[[lowerCasePinyinStr substringWithRange:NSMakeRange(indexOfUnmarkedVowel + 1, lowerCasePinyinStr.length-indexOfUnmarkedVowel)] stringByReplacingOccurrencesOfString:@"v" withString:@"ü"]];
+		[resultBuffer appendString:[[lowerCasePinyinStr substringToIndex:indexOfUnmarkedVowel] stringByReplacingOccurrencesOfString:@"v" withString:@"ü"]];
+		[resultBuffer appendFormat:@"%C",markedVowel];
+		[resultBuffer appendString:[lowerCasePinyinStr substringWithRange:NSMakeRange(indexOfUnmarkedVowel + 1, (lowerCasePinyinStr.length - indexOfUnmarkedVowel) - 2)]];
         return [resultBuffer description];
       }
       else {


### PR DESCRIPTION
convertToneNumber2ToneMarkWithNSString causes an out of bounds
exception.

I noticed this when trying to return PinYin with tone marks.
